### PR TITLE
[PEDSP-635] Set gem host

### DIFF
--- a/html5_zip_file.gemspec
+++ b/html5_zip_file.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # delete this section to allow pushing this gem to any host.
   raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.' unless spec.respond_to?(:metadata)
 
-  spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  spec.metadata['allowed_push_host'] = 'https://adgear.jfrog.io/artifactory/api/gems/gems'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
A gem host was never set for this gem. I am having some issue uploading this new version to artifactory and I think that setting the correct gem host will help unblock me in this process.